### PR TITLE
BI-2681 - Migrate brapi server fork to be based off of prod server instead of test server

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,20 +8,77 @@ on:
       - brapi-server-v2
       
   workflow_dispatch:
+    inputs:
+      upstream_repo:
+        description: 'Optional: Override upstream repository (owner/repo). Defaults to the repository this was forked from if not set.'
+        required: false
+        type: string
+      upstream_pr_number:
+        description: 'Required if merging an upstream PR: PR number from the upstream repository to merge into develop for this build.'
+        required: false # Still false overall, but logic will require it if this feature is used.
+        type: string
 
 jobs:
   docker:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout develop branch
+        uses: actions/checkout@v4
+        with:
+          ref: develop # Default to develop, will be overridden by push events to other branches
+          # token: ${{ secrets.PAT_TOKEN }} # Uncomment if upstream repo is private and requires a PAT
       
+      - name: Conditionally Fetch and Merge Upstream PR
+        # This step runs if a PR number is provided AND (an upstream_repo input is given OR a parent repo full_name is available)
+        if: |
+          github.event.inputs.upstream_pr_number && \
+          (github.event.inputs.upstream_repo || github.event.repository.parent.full_name)
+        run: |
+          UPSTREAM_REPO_SPECIFIED="${{ github.event.inputs.upstream_repo }}"
+          UPSTREAM_REPO_PARENT="${{ github.event.repository.parent.full_name }}"
+          UPSTREAM_PR_NUMBER="${{ github.event.inputs.upstream_pr_number }}"
+
+          if [[ -z "$UPSTREAM_PR_NUMBER" ]]; then
+            echo "No upstream PR number provided. Skipping PR merge."
+            exit 0
+          fi
+
+          TARGET_UPSTREAM_REPO=""
+          if [[ -n "$UPSTREAM_REPO_SPECIFIED" ]]; then
+            TARGET_UPSTREAM_REPO="$UPSTREAM_REPO_SPECIFIED"
+            echo "Using specified upstream repository: $TARGET_UPSTREAM_REPO"
+          elif [[ -n "$UPSTREAM_REPO_PARENT" ]]; then
+            TARGET_UPSTREAM_REPO="$UPSTREAM_REPO_PARENT"
+            echo "Using parent repository as upstream: $TARGET_UPSTREAM_REPO"
+          else
+            echo "Error: Upstream PR number '$UPSTREAM_PR_NUMBER' was provided, but no upstream_repo was specified and parent repository could not be determined."
+            exit 1
+          fi
+
+          echo "Upstream PR to merge: $UPSTREAM_PR_NUMBER from $TARGET_UPSTREAM_REPO"
+          UPSTREAM_REPO_URL="https://github.com/$TARGET_UPSTREAM_REPO.git"
+
+          # Fetch the PR from the upstream repository
+          git fetch $UPSTREAM_REPO_URL +refs/pull/$UPSTREAM_PR_NUMBER/head:upstream_pr_branch
+
+          echo "Fetched PR branch 'upstream_pr_branch'. Merging into current HEAD (develop)..."
+          # Merge the fetched PR branch. If conflicts occur, the script will exit with an error.
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git merge upstream_pr_branch --no-ff -m "Merge upstream PR #$UPSTREAM_PR_NUMBER from $TARGET_UPSTREAM_REPO for testing"
+
+          echo "Merge complete."
+        shell: bash
+
       - name: Extract branch name
         shell: bash
         run: echo ::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})
         id: extract_branch
         
-      - run: git pull origin ${{steps.extract_branch.outputs.branch}}
+      # This pull is no longer needed as checkout handles fetching the correct ref,
+      # and the PR merge step brings in specific upstream changes.
+      # - run: git pull origin ${{steps.extract_branch.outputs.branch}}
       
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -45,20 +102,47 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Set tag
-        id: vars
-        run: echo ::set-output name=imageName::$(echo breedinginsight/brapi-java-server:${{ github.run_number }})
+
+      - name: Determine Docker Tags
+        id: docker_tags
+        shell: bash
+        run: |
+          PR_NUMBER="${{ github.event.inputs.upstream_pr_number }}"
+          IMAGE_BASE_NAME="breedinginsight/brapi-java-server"
+          TAGS=""
+
+          if [[ -n "$PR_NUMBER" ]]; then
+            echo "This is a PR build. Setting PR-specific tag."
+            PR_TAG="$IMAGE_BASE_NAME:pr-$PR_NUMBER"
+            TAGS="$PR_TAG"
+            echo "::set-output name=is_pr_build::true"
+          else
+            echo "This is a regular build. Setting standard tags."
+            RUN_NUMBER_TAG="$IMAGE_BASE_NAME:${{ github.run_number }}"
+            TAGS="$RUN_NUMBER_TAG"
+
+            BRANCH_NAME="${{ steps.extract_branch.outputs.branch }}"
+            STREAM_NAME=""
+            if [[ "$BRANCH_NAME" == "develop" ]]; then
+              STREAM_NAME="$IMAGE_BASE_NAME:develop"
+            elif [[ "$BRANCH_NAME" == "brapi-server-v2" ]]; then # Assuming brapi-server-v2 is 'latest'
+              STREAM_NAME="$IMAGE_BASE_NAME:latest"
+            elif [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
+              STREAM_NAME="$IMAGE_BASE_NAME:rc"
+            fi
+
+            if [[ -n "$STREAM_NAME" ]]; then
+              TAGS="$TAGS,$STREAM_NAME" # Comma-separated for docker/build-push-action or loop for docker buildx build
+            fi
+            echo "::set-output name=is_pr_build::false"
+          fi
+          echo "Final tags: $TAGS"
+          echo "::set-output name=tags::$TAGS"
         
-      - name: Tag develop
-        if: steps.extract_branch.outputs.branch == 'develop'
-        run: echo "streamName=breedinginsight/brapi-java-server:develop" >> $GITHUB_ENV
-      - name: Tag release candidate
-        if: contains(github.ref, '/release/')
-        run: echo "streamName=breedinginsight/brapi-java-server:rc" >> $GITHUB_ENV
-      - name: Tag latest
-        if: steps.extract_branch.outputs.branch == 'brapi-server-v2'
-        run: echo "streamName=breedinginsight/brapi-java-server:latest" >> $GITHUB_ENV
+      # The original 'Set tag' and 'Tag develop/rc/latest' steps are now incorporated into 'Determine Docker Tags'
+      # and are conditioned by is_pr_build logic within that step.
 
       - name: Build Docker and push image
         run: |
-          docker buildx build . --file Dockerfile --tag ${{steps.vars.outputs.imageName}} --tag ${{env.streamName}} --push --platform=linux/arm64,linux/amd64
+          FORMATTED_TAGS=$(echo "${{ steps.docker_tags.outputs.tags }}" | sed 's/,/ --tag /g')
+          docker buildx build . --file Dockerfile --tag $FORMATTED_TAGS --push --platform=linux/arm64,linux/amd64


### PR DESCRIPTION
Modifies the Docker build workflow to use PR-specific tags when building with an upstream PR merged.

- If `upstream_pr_number` is provided:
  - The Docker image will be tagged exclusively as `breedinginsight/brapi-java-server:pr-<PR_NUMBER>`.
  - Standard tagging (run number, develop, rc, latest) is skipped.
- If no `upstream_pr_number` is provided (regular build):
  - The original tagging logic applies (run number + stream name).

This is achieved by a new 'Determine Docker Tags' step that centralizes tag generation logic, and updating the build step to consume these tags.