### PR TITLE
Fix NPE use cases when level name entities table is empty

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitLevelNameService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitLevelNameService.java
@@ -76,7 +76,7 @@ public class ObservationUnitLevelNameService {
                         .filter(ouln -> ouln.getLevelName().equals(sln.getLevelName()))
                         .findFirst()
                         .ifPresent(ouln -> verifiedEntitiesByLevelName.put(ouln.getLevelName(), ouln));
-            } else if (StringUtils.isNotBlank(sln.getProgramDbId())  && StringUtils.isNotBlank(sln.getLevelName()) && foundLevelEntitiesGroupedByProgramId.get(parentProgramDbId) != null) {
+            } else if (StringUtils.isNotBlank(sln.getProgramDbId())  && StringUtils.isNotBlank(sln.getLevelName()) && foundLevelEntitiesGroupedByProgramId.get(sln.getProgramDbId()) != null) {
                 List<ObservationUnitLevelNameEntity> entities = foundLevelEntitiesGroupedByProgramId.get(sln.getProgramDbId());
 
                 entities.stream()
@@ -85,7 +85,7 @@ public class ObservationUnitLevelNameService {
                         .ifPresent(ouln -> verifiedEntitiesByLevelName.put(ouln.getLevelName(), ouln));
             }
 
-            if (verifiedLevelNamesCurrentSize == verifiedEntitiesByLevelName.size()) {
+            if (verifiedLevelNamesCurrentSize == verifiedEntitiesByLevelName.size() && foundLevelEntitiesGroupedByProgramId.get(GLOBAL_KEY_FOR_FOUND_ENTITIES) != null) {
                 // All other ways of detecting the level name have failed so far, try the global ones as a last-ditch effort
                 List<ObservationUnitLevelNameEntity> globalEntities = foundLevelEntitiesGroupedByProgramId.get(GLOBAL_KEY_FOR_FOUND_ENTITIES);
 


### PR DESCRIPTION
# Description
**Story:** [BI-2818](https://breedinginsight.atlassian.net/browse/BI-2818)

_Please include a summary of the change that was made._

Fixed a NPE that can happen when no level names are present in the DB for global level names, as well as a use case when the level name of a submitted OU with OU level program is submitted.

# Dependencies

# Testing
After merging this change verify that rerunning unit tests for [BI-2803](https://breedinginsight.atlassian.net/browse/BI-2803) works.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2818]: https://breedinginsight.atlassian.net/browse/BI-2818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-2803]: https://breedinginsight.atlassian.net/browse/BI-2803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ