### PR TITLE
[BI-2808] Update OULN indices and update code to support them

### DIFF
--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitLevelNameService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitLevelNameService.java
@@ -2,6 +2,7 @@ package org.brapi.test.BrAPITestServer.service.pheno;
 
 import io.swagger.model.pheno.ObservationLevelNewRequest;
 import io.swagger.model.pheno.ObservationUnitHierarchyLevel;
+import io.swagger.model.pheno.ObservationUnitLevel;
 import org.apache.commons.lang3.StringUtils;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerDbIdNotFoundException;
 import org.brapi.test.BrAPITestServer.exceptions.BrAPIServerException;
@@ -30,6 +31,10 @@ public class ObservationUnitLevelNameService {
     private final static String GLOBAL_AND_PROGRAMMATIC_SET_MSG = "Both programDbId and global=true attributes are set. " +
             "A level name cannot be both related to a program and be globally accessible.  Choose one.";
 
+    private final static String NO_DB_ID_PROVIDED_MSG = "A level name associated with a program was provided that has more than one level order associated with it." +
+            " Once this kind of level name is in the database it is recommended to always provide levelNameDbIds for the level names submitted to get the correct level order." +
+            "  Please search for the levelNameDbId for the submitted level names in the GET /observationlevelnames endpoint and provide them.";
+
     private final static String GLOBAL_KEY_FOR_FOUND_ENTITIES = "global";
 
     @Autowired
@@ -40,74 +45,70 @@ public class ObservationUnitLevelNameService {
     }
 
     /**
-     * Returns the verified level name entity.  Should only be used with a list of size 1.
+     * Returns the verified level name entity.  Should only be used with a list of size 1, lists are only used here
+     * to use the wildcard since there are different children of ObservationUnitLevel used in the callers of this method.
      */
     public ObservationUnitLevelNameEntity verifyObservationUnitLevelName(String parentProgramDbId,
-                                                                         List<? extends ObservationUnitHierarchyLevel> submittedLevelName,
+                                                                         List<? extends ObservationUnitLevel> submittedLevelNames,
                                                                          Map<String, ObservationUnitLevelNameEntity> foundLevelEntitiesByDbId,
                                                                          Map<String, List<ObservationUnitLevelNameEntity>> foundLevelEntitiesGroupedByProgramId)
         throws BrAPIServerException {
 
-        return verifyObservationUnitLevelNames(parentProgramDbId, submittedLevelName,
-                foundLevelEntitiesByDbId,
-                foundLevelEntitiesGroupedByProgramId).get(submittedLevelName.getFirst().getLevelName());
-    }
-
-    public Map<String, ObservationUnitLevelNameEntity> verifyObservationUnitLevelNames(String parentProgramDbId,
-                                                                                       List<? extends ObservationUnitHierarchyLevel> submittedLevelNames,
-                                                                                       Map<String, ObservationUnitLevelNameEntity> foundLevelEntitiesByDbId,
-                                                                                       Map<String, List<ObservationUnitLevelNameEntity>> foundLevelEntitiesGroupedByProgramId)
-        throws BrAPIServerException {
-
-        Map<String, ObservationUnitLevelNameEntity> verifiedEntitiesByLevelName = new HashMap<>();
-        List<ObservationUnitHierarchyLevel> levelNamesNotFound = new ArrayList<>();
-
-        submittedLevelNames.forEach(sln -> {
-
-            var verifiedLevelNamesCurrentSize = verifiedEntitiesByLevelName.size();
-
-            if (StringUtils.isNotBlank(sln.getLevelNameDbId()) && foundLevelEntitiesByDbId.containsKey(sln.getLevelNameDbId())) {
-                ObservationUnitLevelNameEntity entity = foundLevelEntitiesByDbId.get(sln.getLevelNameDbId());
-                verifiedEntitiesByLevelName.put(entity.getLevelName(), entity);
-            } else if (StringUtils.isNotBlank(parentProgramDbId) && StringUtils.isNotBlank(sln.getLevelName()) && foundLevelEntitiesGroupedByProgramId.get(parentProgramDbId) != null) {
-                List<ObservationUnitLevelNameEntity> entities = foundLevelEntitiesGroupedByProgramId.get(parentProgramDbId);
-
-                entities.stream()
-                        .filter(ouln -> ouln.getLevelName().equals(sln.getLevelName()))
-                        .findFirst()
-                        .ifPresent(ouln -> verifiedEntitiesByLevelName.put(ouln.getLevelName(), ouln));
-            } else if (StringUtils.isNotBlank(sln.getProgramDbId())  && StringUtils.isNotBlank(sln.getLevelName()) && foundLevelEntitiesGroupedByProgramId.get(sln.getProgramDbId()) != null) {
-                List<ObservationUnitLevelNameEntity> entities = foundLevelEntitiesGroupedByProgramId.get(sln.getProgramDbId());
-
-                entities.stream()
-                        .filter(ouln -> ouln.getLevelName().equals(sln.getLevelName()))
-                        .findFirst()
-                        .ifPresent(ouln -> verifiedEntitiesByLevelName.put(ouln.getLevelName(), ouln));
-            }
-
-            if (verifiedLevelNamesCurrentSize == verifiedEntitiesByLevelName.size() && foundLevelEntitiesGroupedByProgramId.get(GLOBAL_KEY_FOR_FOUND_ENTITIES) != null) {
-                // All other ways of detecting the level name have failed so far, try the global ones as a last-ditch effort
-                List<ObservationUnitLevelNameEntity> globalEntities = foundLevelEntitiesGroupedByProgramId.get(GLOBAL_KEY_FOR_FOUND_ENTITIES);
-
-                globalEntities.stream()
-                        .filter(ouln -> ouln.getLevelName().equals(sln.getLevelName()))
-                        .findFirst()
-                        .ifPresent(ouln -> verifiedEntitiesByLevelName.put(ouln.getLevelName(), ouln));
-            }
-
-            if (verifiedLevelNamesCurrentSize == verifiedEntitiesByLevelName.size()) {
-                // This level name was not found. Add it to the list to notify user which level names are invalid.
-                levelNamesNotFound.add(sln);
-            }
-        });
-
-        if (!levelNamesNotFound.isEmpty()) {
-            throw new BrAPIServerException(HttpStatus.BAD_REQUEST, String.format("The following submitted level names were not found: [%s]. " +
-                    " Please check that these level names exist in the DB by using the /observationlevelnames endpoints.  If they do not exist, they can be added there.",
-                    levelNamesNotFound));
+        if (submittedLevelNames.size() > 1) {
+            throw new IllegalArgumentException();
         }
 
-        return verifiedEntitiesByLevelName;
+        ObservationUnitLevel submittedLevelName = submittedLevelNames.getFirst();
+
+        ObservationUnitLevelNameEntity verifiedEntity = null;
+
+        if (StringUtils.isNotBlank(submittedLevelName.getLevelNameDbId()) && foundLevelEntitiesByDbId.containsKey(submittedLevelName.getLevelNameDbId())) {
+            verifiedEntity = foundLevelEntitiesByDbId.get(submittedLevelName.getLevelNameDbId());
+        } else if (StringUtils.isNotBlank(parentProgramDbId) && StringUtils.isNotBlank(submittedLevelName.getLevelName()) && foundLevelEntitiesGroupedByProgramId.get(parentProgramDbId) != null) {
+            // If parent programDbId is provided, utilize it to look up the level name.
+            List<ObservationUnitLevelNameEntity> entitiesMatchedByName = foundLevelEntitiesGroupedByProgramId.get(parentProgramDbId)
+                    .stream()
+                    .filter(ouln -> ouln.getLevelName().equals(submittedLevelName.getLevelName()))
+                    .limit(2)
+                    .toList();
+
+            if (entitiesMatchedByName.size() > 1) {
+                throw new BrAPIServerException(HttpStatus.BAD_REQUEST, NO_DB_ID_PROVIDED_MSG);
+            } else if (entitiesMatchedByName.size() == 1) {
+                verifiedEntity = entitiesMatchedByName.getFirst();
+            }
+        } else if (StringUtils.isNotBlank(submittedLevelName.getProgramDbId())  && StringUtils.isNotBlank(submittedLevelName.getLevelName()) && foundLevelEntitiesGroupedByProgramId.get(submittedLevelName.getProgramDbId()) != null) {
+            // Parent programDbId was not provided, if there's a programDbId inside the levelName itself try using that to get the level name.
+            List<ObservationUnitLevelNameEntity> entitiesMatchByName = foundLevelEntitiesGroupedByProgramId.get(submittedLevelName.getProgramDbId())
+                    .stream()
+                    .filter(ouln -> ouln.getLevelName().equals(submittedLevelName.getLevelName()))
+                    .limit(2)
+                    .toList();
+
+            if (entitiesMatchByName.size() > 1) {
+                throw new BrAPIServerException(HttpStatus.BAD_REQUEST, NO_DB_ID_PROVIDED_MSG);
+            } else if (entitiesMatchByName.size() == 1) {
+                verifiedEntity = entitiesMatchByName.getFirst();
+            }
+        }
+
+        if (verifiedEntity == null && foundLevelEntitiesGroupedByProgramId.get(GLOBAL_KEY_FOR_FOUND_ENTITIES) != null) {
+            // All other ways of detecting the level name have failed so far, try the global ones as a last-ditch effort
+            List<ObservationUnitLevelNameEntity> globalEntities = foundLevelEntitiesGroupedByProgramId.get(GLOBAL_KEY_FOR_FOUND_ENTITIES);
+
+            verifiedEntity = globalEntities.stream()
+                    .filter(ouln -> ouln.getLevelName().equals(submittedLevelName.getLevelName()))
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        if (verifiedEntity == null) {
+            throw new BrAPIServerException(HttpStatus.BAD_REQUEST, String.format("The following submitted level names were not found: [%s]. " +
+                            " Please check that these level names exist in the DB by using the /observationlevelnames endpoints.  If they do not exist, they can be added there.",
+                    submittedLevelName));
+        }
+
+        return verifiedEntity;
     }
 
     /**

--- a/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitService.java
+++ b/src/main/java/org/brapi/test/BrAPITestServer/service/pheno/ObservationUnitService.java
@@ -818,7 +818,7 @@ public class ObservationUnitService {
 		if (position.getObservationLevel() != null) {
 			if (position.getObservationLevel().getLevelCode() != null)
 				pEntity.setLevelCode(position.getObservationLevel().getLevelCode());
-			if (position.getObservationLevel().getLevelName() != null) {
+			if (position.getObservationLevel() != null) {
 				var parentProgramDbId = Optional.ofNullable(ouEntity.getProgram())
 						.map(p -> p.getId().toString())
 						.orElse(null);
@@ -860,17 +860,19 @@ public class ObservationUnitService {
 				.map(p -> p.getId().toString())
 				.orElse(null);
 
-		var foundOULevelNames = observationUnitLevelNameService.verifyObservationUnitLevelNames(programDbId,
-				position.getObservationLevelRelationships(),
-				foundLevelNameEntitiesByDbId,
-				foundLevelNamesGroupedByProgramId);
-
 		var relationshipEntities = new ArrayList<ObservationUnitLevelRelationshipEntity>();
 
 		for (ObservationUnitLevelRelationship level : position.getObservationLevelRelationships()) {
 			ObservationUnitLevelRelationshipEntity relationshipEntity = new ObservationUnitLevelRelationshipEntity();
 			relationshipEntity.setLevelCode(level.getLevelCode());
-			relationshipEntity.setLevelName(foundOULevelNames.get(level.getLevelName()));
+
+			var foundOULevelName = observationUnitLevelNameService.verifyObservationUnitLevelName(programDbId,
+					List.of(level),
+					foundLevelNameEntitiesByDbId,
+					foundLevelNamesGroupedByProgramId);
+
+			relationshipEntity.setLevelName(foundOULevelName);
+
 			if (level.getObservationUnitDbId() != null) {
 				ObservationUnitEntity parentEntity = getObservationUnitEntity(level.getObservationUnitDbId());
 				relationshipEntity.setObservationUnit(parentEntity);

--- a/src/main/resources/db/migration/U005.004__revert_level_name_schema.sql
+++ b/src/main/resources/db/migration/U005.004__revert_level_name_schema.sql
@@ -1,3 +1,8 @@
+ALTER TABLE observation_unit_level_name
+ALTER COLUMN level_order DROP NOT NULL;
+
 DROP INDEX lvl_name_program_order_idx;
 
-CREATE UNIQUE INDEX lvl_name_program_id_idx ON observation_unit_level_name (level_name, program_id);
+-- There could be scenarios where the previous unique index is unable to be made.  A non-unique index with the same name
+-- will allow the existing migration to run again in the event of an undo.
+CREATE INDEX lvl_name_program_id_idx ON observation_unit_level_name (level_name, program_id);

--- a/src/main/resources/db/migration/U005.004__revert_level_name_schema.sql
+++ b/src/main/resources/db/migration/U005.004__revert_level_name_schema.sql
@@ -1,0 +1,3 @@
+DROP INDEX lvl_name_program_order_idx;
+
+CREATE UNIQUE INDEX lvl_name_program_id_idx ON observation_unit_level_name (level_name, program_id);

--- a/src/main/resources/db/migration/V005.004__level_name_schema_update.sql
+++ b/src/main/resources/db/migration/V005.004__level_name_schema_update.sql
@@ -1,0 +1,3 @@
+DROP INDEX lvl_name_program_id_idx;
+
+CREATE UNIQUE INDEX lvl_name_program_order_idx ON observation_unit_level_name (level_name, program_id, level_order);

--- a/src/main/resources/db/migration/V005.004__level_name_schema_update.sql
+++ b/src/main/resources/db/migration/V005.004__level_name_schema_update.sql
@@ -1,3 +1,8 @@
+UPDATE observation_unit_level_name SET level_order = 0 where level_order IS NULL;
+
+ALTER TABLE observation_unit_level_name
+ALTER COLUMN level_order SET NOT NULL;
+
 DROP INDEX lvl_name_program_id_idx;
 
 CREATE UNIQUE INDEX lvl_name_program_order_idx ON observation_unit_level_name (level_name, program_id, level_order);


### PR DESCRIPTION
# Description
**Story:** [BI-2808](https://breedinginsight.atlassian.net/browse/BI-2808)

* Updated observation_unit_level_name table to have `level_name`, `program_id`, and 'level_order' be a unique key.  Removed the old key on program and level name.
* Updated the code to support this new schema.
* Updated the code to more thoroughly support submitting levelNameDbIds instead of level name, which is the intended way to submit level names with OUs when not simply using global level names.  Previously this seemed to not work the way as intended, so code was updated to make it more deterministic for each submitted level.
* Added a new error message when level names are provided with no dbIds and the level names match against multiple level names with the same name for the program but with different level orders, instructing the user to send dbIds in this use case and from now on.


# Dependencies

# Testing
* Verify that when I post a level name to BrAPI via /observationlevelnames, I am able to create level names like:
* * name=Peanut, levelOrder=0, programDbId='aca92663-3556-4495-94e8-c6c1bd90bf5c'
* * name=Peanut, levelOrder=1, programDbId= ‘aca92663-3556-4495-94e8-c6c1bd90bf5c’
* Verify that I am met with a 409 duplicate error with a valid response when I post two level names like:
* * name=Peanut, levelOrder=0, programDbId='aca92663-3556-4495-94e8-c6c1bd90bf5c'
* * name=Peanut, levelOrder=0, programDbId='aca92663-3556-4495-94e8-c6c1bd90bf5c'
* Verify that when I create new observation units I can match level names with dbIds provided from the observationlevelnames endpoints.
* Verify that when I create new observation units and I provide a levelName without a levelNameDbId, if there are more than two level names with the same programId then an error is thrown telling me to provide a levelNameDbId so i can get the correct level name with the level order I expect.
# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have either updated the source of truth or arranged for update with product owner if needed https://breedinginsight.atlassian.net/wiki/spaces/BI/pages/1559953409/Source+of+Truth


[BI-2808]: https://breedinginsight.atlassian.net/browse/BI-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ